### PR TITLE
beer-song: no double linebreaks in last verse

### DIFF
--- a/exercises/beer-song/beer_song_test.py
+++ b/exercises/beer-song/beer_song_test.py
@@ -46,7 +46,7 @@ class BeerTest(unittest.TestCase):
             "6 bottles of beer on the wall.\n\n"
             "6 bottles of beer on the wall, 6 bottles of beer.\n"
             "Take one down and pass it around, "
-            "5 bottles of beer on the wall.\n\n"
+            "5 bottles of beer on the wall.\n"
         )
 
     def test_song_all_the_rest_of_the_verses(self):
@@ -63,7 +63,7 @@ class BeerTest(unittest.TestCase):
             "no more bottles of beer on the wall.\n\n"
             "No more bottles of beer on the wall, no more bottles of beer.\n"
             "Go to the store and buy some more, "
-            "99 bottles of beer on the wall.\n\n"
+            "99 bottles of beer on the wall.\n"
         )
 
 


### PR DESCRIPTION
Pass `song()`-tests only if the last verse has only *one* linebreak.

Momentarily, the test suit asks for `\n\n` after each verse, including the last verse. That is not beautiful. I would even go as far as deleting the last `\n` completely but that might be to big a change as that would also affect the `verse()`-tests.